### PR TITLE
Feature/composite class to struct

### DIFF
--- a/CompositeClassToStruct/CompositeClass.cpp
+++ b/CompositeClassToStruct/CompositeClass.cpp
@@ -1,0 +1,23 @@
+#include "CompositeClass.h"
+
+#include <iostream>
+
+void CompositeClass::add(Animal* a) 
+{
+    mAnimalKingdom.emplace_back(a);
+}
+
+/**
+* @brief    Returns the composition as a POD struct.
+*/
+PlainStruct CompositeClass::get()
+{
+    PlainStruct plainStruct{};
+    plainStruct.alpha = mAnimalKingdom.back().get()->id();
+    mAnimalKingdom.pop_back();
+    plainStruct.beta = mAnimalKingdom.back().get()->id();
+
+    std::cout << plainStruct.alpha << " " << plainStruct.beta << std::endl;
+    
+    return plainStruct;
+}

--- a/CompositeClassToStruct/CompositeClass.cpp
+++ b/CompositeClassToStruct/CompositeClass.cpp
@@ -9,11 +9,11 @@ void CompositeClass::add(Animal* a)
 
 /**
 * @brief    Returns the composition as a POD struct.
+* @remark   The full POD struct could be collectively hard-to-copy. As such, experiment with returning a handle to a
+*           dynamically allocated POD struct.
 */
 std::unique_ptr<PlainStruct> CompositeClass::get()
 {
-    //PlainStruct plainStruct{};
-
     std::unique_ptr<PlainStruct> plainStruct{ new PlainStruct{} };
 
     plainStruct->alpha = mAnimalKingdom.back().get()->id();

--- a/CompositeClassToStruct/CompositeClass.cpp
+++ b/CompositeClassToStruct/CompositeClass.cpp
@@ -10,14 +10,17 @@ void CompositeClass::add(Animal* a)
 /**
 * @brief    Returns the composition as a POD struct.
 */
-PlainStruct CompositeClass::get()
+std::unique_ptr<PlainStruct> CompositeClass::get()
 {
-    PlainStruct plainStruct{};
-    plainStruct.alpha = mAnimalKingdom.back().get()->id();
-    mAnimalKingdom.pop_back();
-    plainStruct.beta = mAnimalKingdom.back().get()->id();
+    //PlainStruct plainStruct{};
 
-    std::cout << plainStruct.alpha << " " << plainStruct.beta << std::endl;
+    std::unique_ptr<PlainStruct> plainStruct{ new PlainStruct{} };
+
+    plainStruct->alpha = mAnimalKingdom.back().get()->id();
+    mAnimalKingdom.pop_back();
+    plainStruct->beta = mAnimalKingdom.back().get()->id();
+
+    std::cout << plainStruct->alpha << " " << plainStruct->beta << std::endl;
     
     return plainStruct;
 }

--- a/CompositeClassToStruct/CompositeClass.h
+++ b/CompositeClassToStruct/CompositeClass.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "PlainStruct.h"
+
+#include <vector>
+#include <memory>
+#include <utility>
+
+/**
+* @brief    Base class
+* @remark   All children will simply return an integer, but VS2013 was being dumb so make this an abstract base class.
+*/
+class Animal
+{
+public:
+    virtual int id() = 0;
+};
+
+/**
+* @brief    Subclass
+*/
+class Cat : public Animal
+{
+public:
+    Cat() = default;
+    ~Cat() = default;
+    Cat(const Cat&) = default;
+    Cat& operator=(const Cat&) = default;
+    int id() { return mId; }
+private:
+    int mId{ 1 };
+};
+
+/**
+* @brief    Subclass
+*/
+class Dog : public Animal
+{
+public:
+    Dog() = default;
+    ~Dog() = default;
+    Dog(const Dog&) = default;
+    Dog& operator=(const Dog&) = default;
+    int id() { return mId; }
+private:
+    int mId{ 2 };
+};
+
+typedef std::unique_ptr<Animal> AnimalPointer;
+typedef std::vector<AnimalPointer> AnimalKingdom;
+
+/**
+* @brief    The composite class that can be turned into a POD struct.
+*/
+class CompositeClass
+{
+public:
+    CompositeClass() = default;
+    void add(Animal* a);
+    PlainStruct get();
+private:
+    AnimalKingdom mAnimalKingdom;
+};
+

--- a/CompositeClassToStruct/CompositeClass.h
+++ b/CompositeClassToStruct/CompositeClass.h
@@ -57,7 +57,7 @@ class CompositeClass
 public:
     CompositeClass() = default;
     void add(Animal* a);
-    PlainStruct get();
+    std::unique_ptr<PlainStruct> get();
 private:
     AnimalKingdom mAnimalKingdom;
 };

--- a/CompositeClassToStruct/CompositeClassToStruct.vcxproj
+++ b/CompositeClassToStruct/CompositeClassToStruct.vcxproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{963D6AF2-29C8-4DA9-894B-28FF871E511D}</ProjectGuid>
+    <RootNamespace>CompositeClassToStruct</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="CompositeClass.cpp" />
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="CompositeClass.h" />
+    <ClInclude Include="PlainStruct.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/CompositeClassToStruct/CompositeClassToStruct.vcxproj.filters
+++ b/CompositeClassToStruct/CompositeClassToStruct.vcxproj.filters
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CompositeClass.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="PlainStruct.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CompositeClass.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/CompositeClassToStruct/PlainStruct.h
+++ b/CompositeClassToStruct/PlainStruct.h
@@ -1,0 +1,10 @@
+#pragma once
+
+/**
+* @brief    A POD struct with only integers and C-style integer arrays.
+*/
+struct PlainStruct
+{
+    int alpha;
+    int beta;
+};

--- a/CompositeClassToStruct/main.cpp
+++ b/CompositeClassToStruct/main.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+
+#include "PlainStruct.h"
+#include "CompositeClass.h"
+
+/**
+*   @brief  Main function in experiment to see how practical it is to have a composite object using OO translate to
+*           a POD struct.
+*/
+int main()
+{
+    std::cout << "hello world" << std::endl;
+
+    PlainStruct p{};
+
+    CompositeClass c{};
+    c.add(new Cat{});
+    c.add(new Dog{});
+    p = c.get();
+
+    char input{};
+    std::cin >> input;
+
+    return 0;
+}

--- a/CompositeClassToStruct/main.cpp
+++ b/CompositeClassToStruct/main.cpp
@@ -16,7 +16,8 @@ int main()
     CompositeClass c{};
     c.add(new Cat{});
     c.add(new Dog{});
-    p = c.get();
+    auto returnedUniquePointer = c.get();
+    p = *returnedUniquePointer;
 
     char input{};
     std::cin >> input;

--- a/CompositeClassToStruct/main.cpp
+++ b/CompositeClassToStruct/main.cpp
@@ -11,13 +11,14 @@ int main()
 {
     std::cout << "hello world" << std::endl;
 
-    PlainStruct p{};
-
     CompositeClass c{};
     c.add(new Cat{});
     c.add(new Dog{});
     auto returnedUniquePointer = c.get();
-    p = *returnedUniquePointer;
+
+    PlainStruct p = *returnedUniquePointer;
+
+    std::cout << "I got " << p.alpha << " and " << p.beta << std::endl;
 
     char input{};
     std::cin >> input;

--- a/Errands.sln
+++ b/Errands.sln
@@ -7,6 +7,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "GroceryShopping", "Project1
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PolymorphismReminder", "PolymorphismReminder\PolymorphismReminder.vcxproj", "{1D29793E-C1E4-47B0-8E3A-1FAC31A22A88}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CompositeClassToStruct", "CompositeClassToStruct\CompositeClassToStruct.vcxproj", "{963D6AF2-29C8-4DA9-894B-28FF871E511D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
@@ -14,12 +16,15 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EC978373-E2CC-47C7-9F68-D3CCF0DC2584}.Debug|Win32.ActiveCfg = Debug|Win32
-		{EC978373-E2CC-47C7-9F68-D3CCF0DC2584}.Debug|Win32.Build.0 = Debug|Win32
 		{EC978373-E2CC-47C7-9F68-D3CCF0DC2584}.Release|Win32.ActiveCfg = Release|Win32
 		{EC978373-E2CC-47C7-9F68-D3CCF0DC2584}.Release|Win32.Build.0 = Release|Win32
 		{1D29793E-C1E4-47B0-8E3A-1FAC31A22A88}.Debug|Win32.ActiveCfg = Debug|Win32
 		{1D29793E-C1E4-47B0-8E3A-1FAC31A22A88}.Release|Win32.ActiveCfg = Release|Win32
 		{1D29793E-C1E4-47B0-8E3A-1FAC31A22A88}.Release|Win32.Build.0 = Release|Win32
+		{963D6AF2-29C8-4DA9-894B-28FF871E511D}.Debug|Win32.ActiveCfg = Debug|Win32
+		{963D6AF2-29C8-4DA9-894B-28FF871E511D}.Debug|Win32.Build.0 = Debug|Win32
+		{963D6AF2-29C8-4DA9-894B-28FF871E511D}.Release|Win32.ActiveCfg = Release|Win32
+		{963D6AF2-29C8-4DA9-894B-28FF871E511D}.Release|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
A quick experiment to see if a composite class can be turned into a plain-old-data `struct`. 

The composite class would be a vector of base class pointers, with each derived class representing a simple integer value. Object Oriented design is used to create a large structure of many easy-to-copy values instead of managing a large, unwieldy `struct`. However, due to constraints, only a plain-old-data structure can be passed around in the larger environment. Therefore, the composite class can be used in the immediate scope and the `struct` can be sent out to the larger scope.